### PR TITLE
Improvements variants filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.9.0] - 2025-03-??
+## [0.9.0] - 2025-03-25
 
 ### Added
 
 - `ledger-manifest`: new `--token` argument, allowing to provide a PAT to evade GitHub API
   limitations when parsing remote manifest (with the `--url` argument).
+- New _property_ to get more info for variants: `variant_param`
+- New filtering options:
+  - `legacy`: to select or not the Apps whose name contains _legacy_ in their name (disabled by default)
+  - `plugin`: to select or not the Apps whose name starts by _app-plugin-_ (disabled by default)
+  - `only_list`: to select only a predefined list of Apps
+  - `exclude_list`: to exclude a predefined list of Apps
+  - `sdk`: to filter apps, based on their SDK (C or Rust)
 
 ## [0.8.0] - 2025-03-06
 

--- a/tests/functional/test_github.py
+++ b/tests/functional/test_github.py
@@ -43,8 +43,12 @@ def test_exchange_branches(exchange):
         exchange.current_branch = "does not exists"
 
 
-def test_exchange_variant(exchange):
+def test_exchange_variant_values(exchange):
     assert exchange.variants == ["exchange"]
+
+
+def test_exchange_variant_param(exchange):
+    assert exchange.variant_param == "COIN"
 
 
 def test_starknet_makefile_path(gh):

--- a/tests/unit/test_github.py
+++ b/tests/unit/test_github.py
@@ -1,35 +1,71 @@
-from dataclasses import dataclass
+from typing import Optional
 from unittest import TestCase
+from unittest.mock import MagicMock
 
-from ledgered.github import Condition, GitHubApps, GitHubLedgerHQ
+from ledgered.github import Condition, GitHubApps, GitHubLedgerHQ, NoManifestException
 
 
-@dataclass
 class AppRepositoryMock:
-    name: str
-    archived: bool = False
-    private: bool = False
+    def __init__(
+        self, name: str, sdk: Optional[str] = "c", archived: bool = False, private: bool = False
+    ):
+        self.name = name
+        self.archived = archived
+        self.private = private
+        self._sdk = sdk
+
+    @property
+    def manifest(self) -> str:
+        if self._sdk:
+            mock = MagicMock()
+            mock.app.sdk = self._sdk
+            return mock
+        else:
+            raise NoManifestException(MagicMock())
 
 
 class TestGitHubApps(TestCase):
     def setUp(self):
-        self.app1 = AppRepositoryMock("app-1")
+        self.app1 = AppRepositoryMock("app-1", sdk="rust")
         self.app2 = AppRepositoryMock("not-app")
         self.app3 = AppRepositoryMock("app-3", private=True)
         self.app4 = AppRepositoryMock("app-4", archived=True)
-        self.apps = GitHubApps([self.app1, self.app2, self.app3, self.app4])
+        self.app5 = AppRepositoryMock("app-plugin-foo")
+        self.app6 = AppRepositoryMock("app-foo-legacy")
+        self.apps = GitHubApps([self.app1, self.app2, self.app3, self.app4, self.app5, self.app6])
 
     def test___init__(self):
-        self.assertListEqual(self.apps, [self.app1, self.app3, self.app4])
+        self.assertListEqual(self.apps, [self.app1, self.app3, self.app4, self.app5, self.app6])
 
     def test_filter(self):
         self.assertCountEqual(self.apps.filter(), self.apps)
         self.assertCountEqual(self.apps.filter(name="3"), [self.app3])
         self.assertCountEqual(self.apps.filter(name="app"), self.apps)
-        self.assertCountEqual(self.apps.filter(archived=Condition.WITHOUT), [self.app1, self.app3])
+        self.assertCountEqual(
+            self.apps.filter(archived=Condition.WITHOUT),
+            [self.app1, self.app3, self.app5, self.app6],
+        )
         self.assertCountEqual(self.apps.filter(archived=Condition.ONLY), [self.app4])
-        self.assertCountEqual(self.apps.filter(private=Condition.WITHOUT), [self.app1, self.app4])
+        self.assertCountEqual(
+            self.apps.filter(private=Condition.WITHOUT),
+            [self.app1, self.app4, self.app5, self.app6],
+        )
         self.assertCountEqual(self.apps.filter(private=Condition.ONLY), [self.app3])
+        self.assertCountEqual(
+            self.apps.filter(legacy=Condition.WITHOUT), [self.app1, self.app3, self.app4, self.app5]
+        )
+        self.assertCountEqual(self.apps.filter(legacy=Condition.ONLY), [self.app6])
+        self.assertCountEqual(
+            self.apps.filter(plugin=Condition.WITHOUT), [self.app1, self.app3, self.app4, self.app6]
+        )
+        self.assertCountEqual(self.apps.filter(plugin=Condition.ONLY), [self.app5])
+        self.assertCountEqual(
+            self.apps.filter(only_list=["app-1", "app-3"]), [self.app1, self.app3]
+        )
+        self.assertCountEqual(
+            self.apps.filter(exclude_list=["app-1", "app-3"]), [self.app4, self.app5, self.app6]
+        )
+        self.assertCountEqual(self.apps.filter(sdk=["rust"]), [self.app1])
 
     def test_first(self):
         self.assertEqual(self.apps.first("3"), self.app3)


### PR DESCRIPTION
Add new Apps filtering options:
- `legacy`: to select or not the Apps whose name contains `legacy` in their name (disabled by default)
- `plugin`: to select or not the Apps whose name starts by `app-plugin` (disabled by default)
- `only_list`: to select only a predefined list of Apps
- `exclude_list`: to exclude a predefined list of Apps
- `sdk`: to filter apps, based on their SDK (C or Rust)
- `sort`: allows to return the json data sorted by `name`

Add `variant_name` property and `get_variants_cfg()`