### PR TITLE
output_pytest_directories will now output a list of name / keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] - 2025-11-24
+
+### Fixed
+
+- `output_pytest_directories` will now output a list of name / keys
+
 ## [0.12.3] - 2025-11-06
 
 ### Fixed

--- a/src/ledgered/manifest/cli.py
+++ b/src/ledgered/manifest/cli.py
@@ -288,10 +288,11 @@ def main() -> None:  # pragma: no cover
                     {"name": test_config.key, "directory": str(test_config.directory)}
                 )
             if isinstance(test_config, TestsConfig):
-                # Also add legacy format to the output list
-                display_content["pytest_directories"].append(
-                    {"name": "tests", "directory": str(test_config.pytest_directory)}
-                )
+                # Also add legacy format to the output list, but only if pytest_directory is defined
+                if test_config.pytest_directory is not None:
+                    display_content["pytest_directories"].append(
+                        {"name": "tests", "directory": str(test_config.pytest_directory)}
+                    )
 
     if args.output_pytest_usecases is not None:
         if len(repo_manifest.pytests) == 0:

--- a/src/ledgered/manifest/cli.py
+++ b/src/ledgered/manifest/cli.py
@@ -284,10 +284,14 @@ def main() -> None:  # pragma: no cover
                 if len(args.output_pytest_directories) == 1:
                     if idx != int(args.output_pytest_directories[0]):
                         continue
-                display_content["pytest_directories"].append(str(test_config.directory))
+                display_content["pytest_directories"].append(
+                    {"name": test_config.key, "directory": str(test_config.directory)}
+                )
             if isinstance(test_config, TestsConfig):
                 # Also add legacy format to the output list
-                display_content["pytest_directories"].append(str(test_config.pytest_directory))
+                display_content["pytest_directories"].append(
+                    {"name": "tests", "directory": str(test_config.pytest_directory)}
+                )
 
     if args.output_pytest_usecases is not None:
         if len(repo_manifest.pytests) == 0:

--- a/tests/functional/manifest/test_cli.py
+++ b/tests/functional/manifest/test_cli.py
@@ -223,6 +223,79 @@ class TestCLIMain(TestCase):
         self.args.url = True
         self.assertIsNone(main())
 
+    def test_output_pytest_directories_v1_text(self):
+        # Test with v1 manifest (legacy format)
+        self.args.output_pytest_directories = []
+        expected_text = """pytest_directories:
+ 0.
+  name: tests
+  directory: tests/functional"""
+        self.assertIsNone(main())
+        self.assertEqual(self.text, expected_text)
+
+    def test_output_pytest_directories_v1_json(self):
+        # Test with v1 manifest (legacy format)
+        self.args.output_pytest_directories = []
+        self.args.json = True
+        expected_json = {"pytest_directories": [{"name": "tests", "directory": "tests/functional"}]}
+        self.assertIsNone(main())
+        self.assertEqual(self.json, expected_json)
+
+    def test_output_pytest_directories_v2_text(self):
+        # Test with v2 manifest
+        self.args.source = TEST_MANIFEST_DIRECTORY / "full_correct_v2.toml"
+        self.args.output_pytest_directories = []
+        expected_text = """pytest_directories:
+ 0.
+  name: standalone
+  directory: tests/path_to_st_tests
+ 1.
+  name: swap
+  directory: tests/swap"""
+        self.assertIsNone(main())
+        self.assertEqual(self.text, expected_text)
+
+    def test_output_pytest_directories_v2_json(self):
+        # Test with v2 manifest
+        self.args.source = TEST_MANIFEST_DIRECTORY / "full_correct_v2.toml"
+        self.args.output_pytest_directories = []
+        self.args.json = True
+        expected_json = {
+            "pytest_directories": [
+                {"name": "standalone", "directory": "tests/path_to_st_tests"},
+                {"name": "swap", "directory": "tests/swap"},
+            ]
+        }
+        self.assertIsNone(main())
+        self.assertEqual(self.json, expected_json)
+
+    def test_output_pytest_directories_v2_single_index_text(self):
+        # Test with v2 manifest, requesting only the first pytest section
+        self.args.source = TEST_MANIFEST_DIRECTORY / "full_correct_v2.toml"
+        self.args.output_pytest_directories = ["0"]
+        expected_text = """pytest_directories:
+ 0.
+  name: standalone
+  directory: tests/path_to_st_tests"""
+        self.assertIsNone(main())
+        self.assertEqual(self.text, expected_text)
+
+    def test_output_pytest_directories_v2_single_index_json(self):
+        # Test with v2 manifest, requesting only the second pytest section
+        self.args.source = TEST_MANIFEST_DIRECTORY / "full_correct_v2.toml"
+        self.args.output_pytest_directories = ["1"]
+        self.args.json = True
+        expected_json = {"pytest_directories": [{"name": "swap", "directory": "tests/swap"}]}
+        self.assertIsNone(main())
+        self.assertEqual(self.json, expected_json)
+
+    def test_output_pytest_directories_minimal_manifest_error(self):
+        # Test error when manifest has no pytest sections
+        self.args.source = TEST_MANIFEST_DIRECTORY / "minimal.toml"
+        self.args.output_pytest_directories = []
+        with self.assertRaises(SystemExit):
+            main()
+
 
 class TestCLIset_parser(TestCase):
     diffMax = None


### PR DESCRIPTION
The reusable workflow currently uses hardcoded offset to retrieve swap test dir
This causes issues on Hedera
New output:
```
{
  "pytest_directories": [
    {"name": "standalone", "directory": "tests/path_to_st_tests"},
    {"name": "swap", "directory": "tests/swap"}
  ]
}

pytest_directories:
 0.
  name: standalone
  directory: tests/path_to_st_tests
 1.
  name: swap
  directory: tests/swap
  ```